### PR TITLE
update for using FortiAnalyzer 6.2.5 and minor bugfixes

### DIFF
--- a/templates/autoscale-existing-vpc.template
+++ b/templates/autoscale-existing-vpc.template
@@ -63,7 +63,7 @@
         },
         "FortiGateInstanceType": {
             "Type": "String",
-            "Default": "c5.large",
+            "Default": "c5.xlarge",
             "AllowedValues": [
                 "t2.small",
                 "t3.small",
@@ -91,7 +91,7 @@
             "Default": "6.2.3",
             "AllowedValues": ["6.2.3"],
             "ConstraintDescription": "must be a valid FortiOS version from the selection.",
-            "Description": "The FortiOS version supported by Fortinet FortiGate Auto Scaling."
+            "Description": "The FortiOS version supported by Fortinet FortiGate Auto Scaling. **IMPORTANT!** Requires a subscription to the Fortinet FortiGate On-demand and/or BYOL AMI(s)."
         },
         "LifecycleHookTimeout": {
             "Type": "Number",
@@ -121,28 +121,28 @@
             "Default": 2,
             "MinValue": 0,
             "ConstraintDescription": "must be a valid number not less than 0.",
-            "Description": "The minimum number of FortiGate instances in the BYOL Auto Scaling group. For specific use cases, set to 0 for On-demand-only, and >= 2 for BYOL-only or hybrid licensing."
+            "Description": "Minimum number of FortiGate instances in the BYOL Auto Scaling group. For specific use cases, set to 0 for On-Demand-only, and >= 2 for BYOL-only or hybrid licensing."
         },
         "FgtAsgMaxSizeByol": {
             "Type": "Number",
             "Default": 2,
             "MinValue": 0,
             "ConstraintDescription": "must be a valid number not less than 0.",
-            "Description": "The maximum number of FortiGate instances in the BYOL Auto Scaling group. For specific use cases, set to 0 for On-demand-only, and >= 2 for BYOL-only or hybrid licensing. This number must be greater than or equal to the Minimum group size (BYOL)."
+            "Description": "Maximum number of FortiGate instances in the BYOL Auto Scaling group. For specific use cases, set to 0 for On-Demand-only, and >= 2 for BYOL-only or hybrid licensing. This number must be greater than or equal to the Minimum group size (BYOL)."
         },
         "FgtAsgDesiredCapacityPayg": {
             "Type": "Number",
             "Default": 0,
             "MinValue": 0,
             "ConstraintDescription": "must be a valid number not less than 0.",
-            "Description": "The number of FortiGate instances the On-demand Auto Scaling group should have at any time. For High Availability in an On-demand-only use case, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for BYOL-only, >= 2 for On-demand-only, and >= 0 for hybrid licensing."
+            "Description": "The number of FortiGate instances the On-Demand Auto Scaling group should have at any time. For High Availability in a On-Demand-only use case, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for BYOL-only, >= 2 for On-Demand-only, and >= 0 for hybrid licensing."
         },
         "FgtAsgMinSizePayg": {
             "Type": "Number",
             "Default": 0,
             "MinValue": 0,
             "ConstraintDescription": "must be a valid number not less than 0.",
-            "Description": "The minimum number of FortiGate instances in the On-demand Auto Scaling group. For specific use cases, set to 0 for BYOL-only, >= 2 for On-demand-only, and >= 0 for hybrid licensing."
+            "Description": "Minimum number of FortiGate instances in the On-Demand Auto Scaling group. For specific use cases, set to 0 for BYOL-only, >= 2 for On-Demand-only, and >= 0 for hybrid licensing."
         },
         "FgtAsgMaxSizePayg": {
             "Type": "Number",
@@ -291,74 +291,50 @@
         },
         "FortiAnalyzerInstanceType": {
             "Type": "String",
-            "Default": "m4.large",
+            "Default": "m5.large",
             "AllowedValues": [
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "c5.large",
-                "c5.xlarge",
-                "c5.2xlarge",
-                "c5.4xlarge",
-                "c5.9xlarge",
-                "c5.12xlarge",
-                "c5.18xlarge",
-                "c5.24xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
                 "h1.2xlarge",
                 "h1.4xlarge",
                 "h1.8xlarge",
-                "h1.16xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
                 "m5.large",
                 "m5.xlarge",
                 "m5.2xlarge",
                 "m5.4xlarge",
-                "m5.8xlarge",
                 "m5.12xlarge",
-                "m5.16xlarge",
-                "m5.24xlarge"
+                "t2.medium",
+                "t2.large",
+                "t2.xlarge"
             ],
             "ConstraintDescription": "must be a valid EC2 instance type.",
             "Description": "The instance type to launch as FortiAnalyzer On-demand instances. There are compute-optimized instances such as m4 and c4 available with different vCPU sizes and bandwidths. For more information about instance types, see https://aws.amazon.com/ec2/instance-types/."
         },
         "FortiAnalyzerVersion": {
             "Type": "String",
-            "Default": "6.2.3",
-            "AllowedValues": ["6.2.3"],
+            "Default": "6.2.5",
+            "AllowedValues": ["6.2.5"],
             "ConstraintDescription": "must choose from the provided options.",
-            "Description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."
+            "Description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling. **IMPORTANT!** Requires a subscription to the Fortinet FortiAnalyzer Centralized Logging/Reporting (10 managed devices) AMI."
         },
         "FortiAnalyzerAutoscaleAdminUsername": {
             "Type": "String",
             "Default": "",
             "AllowedPattern": "^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
             "ConstraintDescription": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
-            "Description": "The name of the secondary administrator level account in the FortiAnalyzer, which Fortinet FortiGate Auto Scaling uses to connect to the FortiAnalyzer to authorize any FortiGate device in the Auto Scaling group. To conform to the FortiAnalyzer naming policy, the username can only contain numbers, lowercase letters, uppercase letters, and hyphens. It cannot start or end with a hyphen (-).  If 'FortiAnalyzer integration' is set to 'no', any input will be ignored."
+            "Description": "The name of the secondary administrator level account in the FortiAnalyzer, which Fortinet FortiGate Auto Scaling uses to connect to the FortiAnalyzer to authorize any FortiGate device in the Auto Scaling group. To conform to the FortiAnalyzer naming policy, the username can only contain numbers, lowercase letters, uppercase letters, and hyphens. It cannot start or end with a hyphen (-)."
         },
         "FortiAnalyzerAutoscaleAdminPassword": {
             "Type": "String",
             "NoEcho": true,
             "Default": "",
             "MaxLength": 128,
-            "Description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation. If 'FortiAnalyzer integration' is set to 'no', any input will be ignored."
+            "Description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
         },
         "FortiAnalyzerCustomPrivateIPAddress": {
             "Type": "String",
             "Default": "",
             "AllowedPattern": "^$|^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]){1}$",
             "ConstraintDescription": "must be a valid IPv4 format.",
-            "Description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
+            "Description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
         },
         "IntegratedNATGatewayOptions": {
             "Type": "String",
@@ -856,7 +832,7 @@
                     "default": "Minimum group size (On-demand)"
                 },
                 "FgtAsgMaxSizePayg": {
-                    "default": "Maximum group size (On-demand)"
+                    "default": "Maximum group size (On-Demand)"
                 },
                 "FgtAsgHealthCheckGracePeriod": {
                     "default": "Health check grace period"

--- a/templates/autoscale-main.template
+++ b/templates/autoscale-main.template
@@ -408,84 +408,84 @@
                 "623": "FGTVM64PAYG623"
             },
             "FortiAnalyzerPayg": {
-                "623": "FAZVM64PAYG623"
+                "625": "FAZVM64PAYG625"
             }
         },
         "AWSAMIRegionMap": {
             "AMI": {
                 "FGTVM64BYOL623": "aws-marketplace/FortiGate-VM64-AWS build8404 (6.2.3) GA-e5936f4a-0d69-479f-919c-d5e158bd4d12-ami-01c5698f7658a8322.4",
                 "FGTVM64PAYG623": "aws-marketplace/FortiGate-VM64-AWSONDEMAND build8404 (6.2.3) GA-3124a694-441c-4ff1-8bf7-4d153be424a6-ami-0462507a813be3282.4",
-                "FAZVM64PAYG623": "aws-marketplace/FortiAnalyzer VM64-AWSOnDemand build1235 (6.2.3) GA-137ae5b3-1f45-4ebd-81bf-93687e21d93e-ami-0750d39819d7caa42.4"
+                "FAZVM64PAYG625": "aws-marketplace/FortiAnalyzer VM64-AWSOnDemand build1307 (6.2.5) GA-5bc06b01-2e8b-4205-b84c-8ac24e5925cb-ami-0ad43fcfba0fdf465.4"
             },
             "ap-northeast-1": {
                 "FGTVM64BYOL623": "ami-0bc8cacacf3dfcfc8",
                 "FGTVM64PAYG623": "ami-0444162d604179bf6",
-                "FAZVM64PAYG623": "ami-0b0dd518b763ae923"
+                "FAZVM64PAYG625": "ami-058bb5281554ea853"
             },
             "ap-northeast-2": {
                 "FGTVM64BYOL623": "ami-0a2a06f3cbde68482",
                 "FGTVM64PAYG623": "ami-065b67d14c722617a",
-                "FAZVM64PAYG623": "ami-03365fee895cc8522"
+                "FAZVM64PAYG625": "ami-091491ec939b91b4a"
             },
             "ap-south-1": {
                 "FGTVM64BYOL623": "ami-053b6c12f13183b41",
                 "FGTVM64PAYG623": "ami-0f6693857523585b8",
-                "FAZVM64PAYG623": "ami-0b18b7bfbda2f5793"
+                "FAZVM64PAYG625": "ami-0f9202563d8cf347d"
             },
             "ap-southeast-1": {
                 "FGTVM64BYOL623": "ami-039c20a560db91564",
                 "FGTVM64PAYG623": "ami-0155fb808596ae522",
-                "FAZVM64PAYG623": "ami-063a043576683a8cd"
+                "FAZVM64PAYG625": "ami-048f31c63e075d14e"
             },
             "ap-southeast-2": {
                 "FGTVM64BYOL623": "ami-0fce8cb38dad71632",
                 "FGTVM64PAYG623": "ami-0b67711c6be07aa0b",
-                "FAZVM64PAYG623": "ami-0d1060f02fae9ea3b"
+                "FAZVM64PAYG625": "ami-079ef4c6aca62da73"
             },
             "ca-central-1": {
                 "FGTVM64BYOL623": "ami-047aac44951feb9fb",
                 "FGTVM64PAYG623": "ami-099941e57393c2225",
-                "FAZVM64PAYG623": "ami-002bde3b72a43df1f"
+                "FAZVM64PAYG625": "ami-00f47a3e5f20cafa1"
             },
             "eu-central-1": {
                 "FGTVM64BYOL623": "ami-050d93bdbc31fcc64",
                 "FGTVM64PAYG623": "ami-0c380ca68f2b1f6e8",
-                "FAZVM64PAYG623": "ami-0223b59251aa9f807"
+                "FAZVM64PAYG625": "ami-0c15ecda03070ed9d"
             },
             "eu-north-1": {
                 "FGTVM64BYOL623": "ami-071a868b96c93d6da",
                 "FGTVM64PAYG623": "ami-0d49417aa3a3912e1",
-                "FAZVM64PAYG623": "ami-0dbf09daca24aa6bf"
+                "FAZVM64PAYG625": "ami-0663c71f97fc203b6"
             },
             "eu-west-1": {
                 "FGTVM64BYOL623": "ami-013de57d4a8680ade",
                 "FGTVM64PAYG623": "ami-0874d1d29263b27ff",
-                "FAZVM64PAYG623": "ami-05f96f24754bb4e00"
+                "FAZVM64PAYG625": "ami-0b8ea17ab0826a944"
             },
             "eu-west-2": {
                 "FGTVM64BYOL623": "ami-0aad5e076fa22e8c4",
                 "FGTVM64PAYG623": "ami-04eba63bb19dbeebe",
-                "FAZVM64PAYG623": "ami-0125f10e7400d460d"
+                "FAZVM64PAYG625": "ami-0b4528aca3c1b55bd"
             },
             "eu-west-3": {
                 "FGTVM64BYOL623": "ami-092a7d4eb40332b32",
                 "FGTVM64PAYG623": "ami-0c104a0848b644152",
-                "FAZVM64PAYG623": "ami-00e2f34ab8b6b16f9"
+                "FAZVM64PAYG625": "ami-0f6435b452cf7c82f"
             },
             "sa-east-1": {
                 "FGTVM64BYOL623": "ami-0feee4be0b03e070d",
                 "FGTVM64PAYG623": "ami-04de901f24e8532db",
-                "FAZVM64PAYG623": "ami-0d9fdeb8c498541b6"
+                "FAZVM64PAYG625": "ami-05bbb60d2960f36a4"
             },
             "us-east-1": {
                 "FGTVM64BYOL623": "ami-056b8cbed90f235f7",
                 "FGTVM64PAYG623": "ami-027f258cda3df62de",
-                "FAZVM64PAYG623": "ami-097ebd38f91b7a4de"
+                "FAZVM64PAYG625": "ami-0aec62149ff70fcbf"
             },
             "us-east-2": {
                 "FGTVM64BYOL623": "ami-02dfca9796bfaff10",
                 "FGTVM64PAYG623": "ami-05a4ac8312f7911b9",
-                "FAZVM64PAYG623": "ami-046abcd4e8711920b"
+                "FAZVM64PAYG625": "ami-0185408b148b00d58"
             },
             "us-gov-west-1": {
                 "FGTVM64BYOL623": "ami-23b28442",
@@ -494,22 +494,22 @@
             "us-west-1": {
                 "FGTVM64BYOL623": "ami-012fa84a251f3e63f",
                 "FGTVM64PAYG623": "ami-0f54d37e47fa994a0",
-                "FAZVM64PAYG623": "ami-0086e6c996c6b1d3a"
+                "FAZVM64PAYG625": "ami-0362a553a3d81e6ab"
             },
             "us-west-2": {
                 "FGTVM64BYOL623": "ami-00efdd54f8b4755da",
                 "FGTVM64PAYG623": "ami-02b9cc036cab1071d",
-                "FAZVM64PAYG623": "ami-0b7bfc2604bf63d33"
+                "FAZVM64PAYG625": "ami-03babf421c5f09e17"
             },
             "ap-east-1": {
                 "FGTVM64BYOL623": "ami-0bfc475f9b1de6da9",
                 "FGTVM64PAYG623": "ami-0437be57fc361c67b",
-                "FAZVM64PAYG623": "ami-62420713"
+                "FAZVM64PAYG625": "ami-02cd3bc5abdee1e2b"
             },
             "me-south-1": {
                 "FGTVM64BYOL623": "ami-0063dcdb7c00646a5",
                 "FGTVM64PAYG623": "ami-0fcd028d7d86a0695",
-                "FAZVM64PAYG623": "ami-0af628a19f5cb6382"
+                "FAZVM64PAYG625": "ami-048340a2b75936111"
             }
         },
         "ProtocolPortMap": {

--- a/templates/autoscale-new-vpc.template
+++ b/templates/autoscale-new-vpc.template
@@ -72,7 +72,7 @@
         },
         "FortiGateInstanceType": {
             "Type": "String",
-            "Default": "c5.large",
+            "Default": "c5.xlarge",
             "AllowedValues": [
                 "t2.small",
                 "t3.small",
@@ -100,7 +100,7 @@
             "Default": "6.2.3",
             "AllowedValues": ["6.2.3"],
             "ConstraintDescription": "must be a valid FortiOS version from the selection.",
-            "Description": "The FortiOS version supported by Fortinet FortiGate Auto Scaling."
+            "Description": "The FortiOS version supported by Fortinet FortiGate Auto Scaling. **IMPORTANT!** Requires a subscription to the Fortinet FortiGate On-demand and/or BYOL AMI(s)."
         },
         "LifecycleHookTimeout": {
             "Type": "Number",
@@ -300,74 +300,50 @@
         },
         "FortiAnalyzerInstanceType": {
             "Type": "String",
-            "Default": "m4.large",
+            "Default": "m5.large",
             "AllowedValues": [
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "c5.large",
-                "c5.xlarge",
-                "c5.2xlarge",
-                "c5.4xlarge",
-                "c5.9xlarge",
-                "c5.12xlarge",
-                "c5.18xlarge",
-                "c5.24xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
                 "h1.2xlarge",
                 "h1.4xlarge",
                 "h1.8xlarge",
-                "h1.16xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
                 "m5.large",
                 "m5.xlarge",
                 "m5.2xlarge",
                 "m5.4xlarge",
-                "m5.8xlarge",
                 "m5.12xlarge",
-                "m5.16xlarge",
-                "m5.24xlarge"
+                "t2.medium",
+                "t2.large",
+                "t2.xlarge"
             ],
             "ConstraintDescription": "must be a valid EC2 instance type.",
-            "Description": "The instance type to launch as FortiAnalyzer On-demand instances. There are compute-optimized instances such as m4 and c4 available with different vCPU sizes and bandwidths. For more information about instance types, see https://aws.amazon.com/ec2/instance-types/."
+            "Description": "The instance type to launch as FortiAnalyzer On-Demand instances. There are t2.small and compute-optimized instances such as m4 and c4 available with different vCPU sizes and bandwidths. For more information about instance types, see https://aws.amazon.com/ec2/instance-types/"
         },
         "FortiAnalyzerVersion": {
             "Type": "String",
-            "Default": "6.2.3",
-            "AllowedValues": ["6.2.3"],
+            "Default": "6.2.5",
+            "AllowedValues": ["6.2.5"],
             "ConstraintDescription": "must choose from the provided options.",
-            "Description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."
+            "Description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling. **IMPORTANT!** Requires a subscription to the Fortinet FortiAnalyzer Centralized Logging/Reporting (10 managed devices) AMI."
         },
         "FortiAnalyzerAutoscaleAdminUsername": {
             "Type": "String",
             "Default": "",
             "AllowedPattern": "^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
             "ConstraintDescription": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
-            "Description": "The name of the secondary administrator level account in the FortiAnalyzer, which Fortinet FortiGate Auto Scaling uses to connect to the FortiAnalyzer to authorize any FortiGate device in the Auto Scaling group. To conform to the FortiAnalyzer naming policy, the username can only contain numbers, lowercase letters, uppercase letters, and hyphens. It cannot start or end with a hyphen (-).  If 'FortiAnalyzer integration' is set to 'no', any input will be ignored."
+            "Description": "The name of the secondary administrator level account in the FortiAnalyzer, which Fortinet FortiGate Auto Scaling uses to connect to the FortiAnalyzer to authorize any FortiGate device in the Auto Scaling group. To conform to the FortiAnalyzer naming policy, the username can only contain numbers, lowercase letters, uppercase letters, and hyphens. It cannot start or end with a hyphen (-)."
         },
         "FortiAnalyzerAutoscaleAdminPassword": {
             "Type": "String",
             "NoEcho": true,
             "Default": "",
             "MaxLength": 128,
-            "Description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation. If 'FortiAnalyzer integration' is set to 'no', any input will be ignored."
+            "Description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
         },
         "FortiAnalyzerCustomPrivateIPAddress": {
             "Type": "String",
             "Default": "",
             "AllowedPattern": "^$|^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]){1}$",
             "ConstraintDescription": "must be a valid IPv4 format.",
-            "Description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
+            "Description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
         },
         "IntegratedNATGatewayOptions": {
             "Type": "String",
@@ -967,7 +943,7 @@
                     "default": "Desired capacity (On-demand)"
                 },
                 "FgtAsgMinSizePayg": {
-                    "default": "Minimum group size (On-demand)"
+                    "default": "Minimum group size (On-Demand)"
                 },
                 "FgtAsgMaxSizePayg": {
                     "default": "Maximum group size (On-demand)"

--- a/templates/create-load-balancer.template
+++ b/templates/create-load-balancer.template
@@ -140,6 +140,12 @@
                         ]
                     ]
                 },
+                "LoadBalancerAttributes": [
+                    {
+                        "Key": "load_balancing.cross_zone.enabled",
+                        "Value": "true"
+                    }
+                ],
                 "Tags": [
                     {
                         "Key": "Name",
@@ -290,6 +296,12 @@
                         ]
                     ]
                 },
+                "LoadBalancerAttributes": [
+                    {
+                        "Key": "load_balancing.cross_zone.enabled",
+                        "Value": "true"
+                    }
+                ],
                 "Tags": [
                     {
                         "Key": "Name",
@@ -499,13 +511,25 @@
         "InternalLoadBalancerDNSName": {
             "Description": "FortiGate protected service load balancer DNS Name",
             "Value": {
-                "Fn::GetAtt": ["InternalLoadBalancer", "DNSName"]
+                "Fn::If": [
+                    "IfNewInternalLoadBalancer",
+                    {
+                        "Fn::GetAtt": ["InternalLoadBalancer", "DNSName"]
+                    },
+                    ""
+                ]
             }
         },
         "InternalTargetGroupArn": {
             "Description": "FortiGate protected service target group ARN",
             "Value": {
-                "Ref": "InternalTargetGroup"
+                "Fn::If": [
+                    "IfNewInternalLoadBalancer",
+                    {
+                        "Ref": "InternalTargetGroup"
+                    },
+                    ""
+                ]
             }
         }
     }


### PR DESCRIPTION
includes:

1. use FortiAnalyzer 6.2.5
2. fixed error when choosing not create internal load balancer.
3. enabled cross-zone load balancing by default.